### PR TITLE
Demo.js: ensure HTMLAudioElement exists

### DIFF
--- a/js/demo.js
+++ b/js/demo.js
@@ -94,7 +94,8 @@ var DEMO =
 		this.ms_soundWaves = initSound( 'sound/waves.mp3' );
 		this.ms_soundRain = initSound( 'sound/rain.mp3' );
 		
-		this.ms_soundWaves.play();
+		if(!typeof this.ms_soundWaves === 'undefined') this.ms_soundWaves.play();
+		else console.log('Sound disabled due to licensing');
 		
 	},
 	
@@ -410,10 +411,12 @@ var DEMO =
 		this.ms_MainDirectionalLight.color.copy( directionalLightColor );
 		this.ms_Ocean.materialOcean.uniforms.u_sunDirection.value.copy( this.ms_MainDirectionalLight.position );
 		if ( raining ) {
-			this.ms_soundRain.play();
+			if(!typeof this.ms_soundRain === 'undefined') this.ms_soundRain.play();
+		else console.log('Sound disabled due to licensing');
 		}
 		else {
-			this.ms_soundRain.pause();
+			if(!typeof this.ms_soundRain === 'undefined') this.ms_soundRain.pause();
+		else console.log('Sound disabled due to licensing');
 		}
 		
 		var sources = [


### PR DESCRIPTION
```
Open source browsers (chromium and firefox) do not have proprietary
```

license support (mp3). These browsers would previously fail to load graphic
elements because of this. This patch enables these browsers to simply not
call the audio elements that caused these problems, and propogates error
message to console.
